### PR TITLE
TZAbstractRODataset.WideStringGetterFromRaw used wrong parameters for…

### DIFF
--- a/src/component/ZAbstractRODataset.pas
+++ b/src/component/ZAbstractRODataset.pas
@@ -1834,7 +1834,7 @@ begin
   if Result then
     PWord(Buffer)^ := Ord(#0)
   else //instead of WStrLCopy
-    PRaw2PUnicode(P, Buffer, LengthInt(L), LengthInt(Max(dsMaxStringSize, FieldSize-2)) shr 1, FClientCP);
+    PRaw2PUnicode(P, Buffer, FClientCP, LengthInt(L), LengthInt(Max(dsMaxStringSize, FieldSize-2)) shr 1);
 end;
 {$ENDIF}
 

--- a/src/dbc/ZDbcIntfs.pas
+++ b/src/dbc/ZDbcIntfs.pas
@@ -2072,7 +2072,6 @@ function TZDriverManager.GetClientVersion(const Url: string): Integer;
 var
   Driver: IZDriver;
 begin
-  Result := -1;
   FDriversCS.Enter;
   try
     Driver := InternalGetDriver(URL);


### PR DESCRIPTION
… PRaw2PUnicode. Also fix a compiler warning.