### PR TITLE
MySQL Metadata changes

### DIFF
--- a/src/dbc/ZDbcMySqlMetadata.pas
+++ b/src/dbc/ZDbcMySqlMetadata.pas
@@ -427,7 +427,10 @@ end;
 }
 function TZMySQLDatabaseInfo.StoresLowerCaseIdentifiers: Boolean;
 begin
-  Result := True; //https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html
+  if Assigned(Metadata) then
+    Result := ((Metadata as TZMySQLDatabaseMetadata).Get_lower_case_table_names > 0)
+  else
+    Result := True; //https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html
 end;
 
 {**
@@ -437,7 +440,10 @@ end;
 }
 function TZMySQLDatabaseInfo.StoresMixedCaseIdentifiers: Boolean;
 begin
-  Result := False; //https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html
+  if Assigned(Metadata) then
+    Result := ((Metadata as TZMySQLDatabaseMetadata).Get_lower_case_table_names = 0)
+  else
+    Result := False; //https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html
 end;
 
 {**

--- a/src/dbc/ZDbcMySqlMetadata.pas
+++ b/src/dbc/ZDbcMySqlMetadata.pas
@@ -1038,7 +1038,7 @@ begin
 
   Flower_case_table_names := $FF;
   FIsMariaDB := false;
-  FIsMySQL := false;
+  FIsMySQL := True;
   FKnowServerType := false;
 end;
 
@@ -3231,7 +3231,7 @@ begin
 end;
 
 {**
-  Tries to detect wether the Server is MAriaDB or MySQL. The result can be
+  Tries to detect whether the Server is MariaDB or MySQL. The result can be
   queried with the methods isMariaDB and isMySQL.
 }
 procedure TZMySQLDatabaseMetadata.detectServerType;
@@ -3241,8 +3241,14 @@ begin
     FKnowServerType := true;
     VersionString := GetDatabaseInfo.GetDatabaseProductName;
     VersionString := LowerCase(VersionString);
-    FIsMariaDB := ZFastCode.Pos('mariadb', VersionString) > 0;
-    FIsMySQL := ZFastCode.Pos('mysql', VersionString) > 0;
+    // FIsMariaDB := ZFastCode.Pos('mariadb', VersionString) > 0;
+    // FIsMySQL := ZFastCode.Pos('mysql', VersionString) > 0;
+    FIsMySQL := True;
+    if ZFastCode.Pos('mariadb', VersionString) > 0 then
+    begin
+      FIsMySQL := False;
+      FIsMariaDB := True;
+    end;
   end;
 end;
 


### PR DESCRIPTION
I tried to break these up into separate commits to make it easier to pick and choose if needed.  The last commit changes all of the metadata result sets to return database in the schema column instead of the catalog column, so this is a breaking change.