### PR TITLE
Changes for LobCacheMode feature.

### DIFF
--- a/src/dbc/ZDbcCachedResultSet.pas
+++ b/src/dbc/ZDbcCachedResultSet.pas
@@ -446,6 +446,10 @@ type
   private
     FResultSet: IZResultSet;
   protected
+    /// <summary>Cycle through the entire result set and cache any uncached
+    ///  lobs as Disconnected '[Disc]'. Needed for the TryKeepDataOnDisconnect
+    ///  feature and lcmOnAccess lob caching.</summary>
+    procedure CacheAllLobs;
     procedure FillColumnsInfo(const ColumnsInfo: TObjectList); virtual;
     procedure Open; override;
     function Fetch: Boolean; virtual;
@@ -1499,6 +1503,10 @@ end;
 }
 function TZAbstractCachedResultSet.GetBlob(ColumnIndex: Integer;
   LobStreamMode: TZLobStreamMode = lsmRead): IZBlob;
+var
+  Current: IZBlob;
+  CLob: IZClob;
+  Newlob: IZBlob;
 begin
 {$IFNDEF DISABLE_CHECKING}
   CheckAvailable;
@@ -1506,6 +1514,15 @@ begin
   if LobStreamMode <> lsmRead then
     PrepareRowForUpdates;
   Result := FRowAccessor.GetBlob(ColumnIndex, LastWasNull);
+  if ((FRowAccessor.LobCacheMode = lcmOnAccess) and (Result <> nil) and not Result.IsCached) then
+  begin
+    Current := Result;
+    if Current.QueryInterface(IZCLob, Clob) = S_OK
+    then Newlob := TZLocalMemCLob.CreateFromClob(Clob, FRowAccessor.GetColumnCodePage(ColumnIndex), ConSettings, FOpenLobStreams)
+    else Newlob := TZLocalMemBLob.CreateFromBlob(Current, FOpenLobStreams);
+    Result := Newlob;
+    FRowAccessor.SetBlob(ColumnIndex, Result);
+  end;
   if (Result = nil) and (LobStreamMode <> lsmRead) then
     Result := CreateLob(ColumnIndex, LobStreamMode);
 end;
@@ -2493,9 +2510,41 @@ end;
 
 { TZCachedResultSet }
 
+procedure TZCachedResultSet.CacheAllLobs;
+var
+  ColumnIndex: Integer;
+  SQLType: TZSQLType;
+  Current: IZBlob;
+  Newlob: IZBlob;
+  LastNull: Boolean;
+begin
+  if ((FRowAccessor.LobCacheMode <> lcmOnLoad) and First) then
+  begin
+    repeat
+      for ColumnIndex := 0 to GetColumnCount - 1 do
+      begin
+        SQLType := FRowAccessor.GetColumnType(ColumnIndex);
+        if SQLType in [stAsciiStream, stUnicodeStream, stBinaryStream] then
+        begin
+          Current := FRowAccessor.GetBlob(ColumnIndex, LastNull);
+          if not Current.IsCached then
+          begin
+            Newlob := TZLocalMemCLob.CreateWithData('[Disc]', 6, ConSettings, FOpenLobStreams);
+            FRowAccessor.SetBlob(ColumnIndex, NewLob);
+          end;
+        end;
+      end;
+    until not Next;
+  end;
+end;
+
 procedure TZCachedResultSet.ClearStatementLink;
 var GenDMLResolver: IZGenerateSQLCachedResolver;
 begin
+  if ((FRowAccessor.LobCacheMode = lcmOnAccess)) then
+    CacheAllLobs;
+//  if FRowAccessor.HasServerLinkedColumns then
+//    raise Exception.Create('Testing');
   if Statement <> nil then
     if not FRowAccessor.HasServerLinkedColumns and IsLastRowFetched and GetMetadata.IsMetadataLoaded then begin
       Statement.FreeOpenResultSetReference(IZResultSet(FWeakIZResultSetPtr));

--- a/src/dbc/ZDbcIntfs.pas
+++ b/src/dbc/ZDbcIntfs.pas
@@ -4351,6 +4351,7 @@ type
   IZBlob = interface(IZLob)
     ['{47D209F1-D065-49DD-A156-EFD1E523F6BF}']
     function IsClob: Boolean;
+    function IsCached: Boolean;
 
     function GetString: RawByteString;
     procedure SetString(const Value: RawByteString);

--- a/src/dbc/ZDbcOracleResultSet.pas
+++ b/src/dbc/ZDbcOracleResultSet.pas
@@ -3898,12 +3898,13 @@ var
       IsNull: Boolean;
   begin
     Lob := GetBlob(ColumnIndex, IsNull);
-    if (Lob <> nil) and (Lob.QueryInterface(IZOracleLob, OCILob) = S_OK) then
-      OCILob.CopyLocator;
+    if not Lob.IsCached then
+      if (Lob <> nil) and (Lob.QueryInterface(IZOracleLob, OCILob) = S_OK) then
+        OCILob.CopyLocator;
   end;
 begin
   inherited FillFromFromResultSet(ResultSet, IndexPairList);
-  if (FHighLobCols > -1) and not FCachedLobs then
+  if (FHighLobCols > -1) and not ((FCachedLobs and (FLobCacheMode = lcmNone)) or (FLobCacheMode = lcmOnLoad)) then
     for i := 0 to IndexPairList.Count -1 do begin
       IndexPair := IndexPairList[i];
       ColumnIndex := IndexPair.ColumnIndex;

--- a/src/dbc/ZDbcResultSet.pas
+++ b/src/dbc/ZDbcResultSet.pas
@@ -1227,6 +1227,7 @@ type
     procedure AfterConstruction; override;
   public //might be obsolete in future
     function IsClob: Boolean;
+    function IsCached:  Boolean;   // mjf:
     function Length: Integer; virtual; abstract;
   public
     function IsEmpty: Boolean; virtual; abstract;
@@ -4769,6 +4770,11 @@ begin
   Result := GetRawByteString(zCP_UTF8);
 end;
 {$ENDIF NO_UTF8STRING}
+
+function TZAbstractLob.IsCached: Boolean;
+begin
+  Result := (Self is TZVarLenDataRefLob);  // True if cached.
+end;
 
 function TZAbstractLob.IsClob: Boolean;
 begin


### PR DESCRIPTION
Changes to test new LobCacheMode feature.  To test "cache lobs on access" change FLobCacheMode := lcmNone; to lcmOnAccess in ZDbcCache.  Adds isCached function to Lobs.  Changes to support TryKeepDataOnDisconnect while still using lcmOnAccess.