### PR TITLE
ZMemTable Stream read error fix. Thanks to Michal!!!

### DIFF
--- a/src/component/ZMemTable.pas
+++ b/src/component/ZMemTable.pas
@@ -581,6 +581,10 @@ Begin
 
          SetLength(buf, fsize);
          AStream.Read(buf[0], fsize);
+
+         If fsize <> Self.Fields[b].DataSize Then
+           SetLength(buf, Self.Fields[b].DataSize);
+
          Self.Fields[b].SetData(buf);
          {$ELSE}
          fsize := ReadInt;
@@ -647,7 +651,7 @@ Procedure TZAbstractMemTable.SaveToStream(AStream: TStream);
 
 Var
  bm: TBookMark;
- a: Integer;
+ a, b: Integer;
  buf: {$IFDEF WITH_TVALUEBUFFER}TValueBuffer{$ELSE}Pointer{$ENDIF};
  ms: TMemoryStream;
 Begin
@@ -693,13 +697,15 @@ Begin
            {$IFDEF WITH_TVALUEBUFFER}
            SetLength(buf, Self.Fields[a].DataSize);
            Self.Fields[a].GetData(buf);
-//           If buf[High(buf)] = 0 Then
-//             For b := High(buf) - 1 DownTo Low(buf) Do
-//               If buf[b] <> 0 Then
-//               Begin
-//                 SetLength(buf, b + 1);
-//                 Break;
-//               End;
+
+           If buf[High(buf)] = 0 Then
+             For b := High(buf) - 1 DownTo Low(buf) Do
+               If buf[b] <> 0 Then
+               Begin
+                 SetLength(buf, b + 1);
+                 Break;
+               End;
+
            WriteInt(Length(buf));
            AStream.Write(buf, Length(buf));
            {$ELSE}

--- a/src/component/ZMemTable.pas
+++ b/src/component/ZMemTable.pas
@@ -561,7 +561,11 @@ Begin
        Begin
          ms := TMemoryStream.Create;
          Try
-           ms.CopyFrom(AStream, ReadInt);
+           fsize := ReadInt;
+
+           If fsize = 0 Then Continue;
+
+           ms.CopyFrom(AStream, fsize);
            ms.Position := 0;
            (Self.Fields[b] As TBlobField).LoadFromStream(ms);
          Finally
@@ -571,11 +575,18 @@ Begin
        Else
        Begin
          {$IFDEF WITH_TVALUEBUFFER}
-         SetLength(buf, ReadInt);
-         AStream.Read(buf[0], Length(buf));
+         fsize := ReadInt;
+
+         If fsize = 0 Then Continue;
+
+         SetLength(buf, fsize);
+         AStream.Read(buf[0], fsize);
          Self.Fields[b].SetData(buf);
          {$ELSE}
          fsize := ReadInt;
+
+         If fsize = 0 Then Continue;
+
          GetMem(buf, fsize);
          Try
            AStream.Read(buf^, fsize);


### PR DESCRIPTION
ms.CopyFrom(AStream, 0) caused everything to be read out from AStream, corrupting the field data AND causing stream read error for the next read operation.