### PR TITLE
Fix TZInterbaseFirebirdColumnInfo.GetPCharFromTextVar returning garbage data with Len = 0 for an empty string value

### DIFF
--- a/src/dbc/ZDbcFirebirdInterbase.pas
+++ b/src/dbc/ZDbcFirebirdInterbase.pas
@@ -2870,8 +2870,10 @@ begin
     then Len := CharOctedLength
     else Len := ZDbcUtils.GetAbsorbedTrailingSpacesLen(Result, CharOctedLength);
   end else begin
-    Result := @PISC_VARYING(sqldata).str[0];
     Len := PISC_VARYING(sqldata).strlen;
+    if Len = 0 
+    then Result := nil // in case of empty string data contains previous value, don't return it
+    else Result := @PISC_VARYING(sqldata).str[0];
   end;
 end;
 


### PR DESCRIPTION
Reported & fix suggested by Milos. See https://zeoslib.sourceforge.io/viewtopic.php?p=216675