### PR TITLE
Fix unit name for Delphi2007

### DIFF
--- a/packages/Delphi2007/ZDbc.dpk
+++ b/packages/Delphi2007/ZDbc.dpk
@@ -108,6 +108,6 @@ contains
   ZDbcSqLiteUtils in '..\..\src\dbc\ZDbcSqLiteUtils.pas',
   ZDbcStatement in '..\..\src\dbc\ZDbcStatement.pas',
   ZDbcUtils in '..\..\src\dbc\ZDbcUtils.pas',
-  ZDbcXmlUtils in '..\..\src\dbc\ZDbcUtils.pas';
+  ZDbcXmlUtils in '..\..\src\dbc\ZDbcXmlUtils.pas';
 
 end.


### PR DESCRIPTION
The unit name in the uses clause is incorrect for Delphi2007.