### PR TITLE
Possible fix for Oracle 1406 errors with UTF16.

### DIFF
--- a/src/dbc/ZDbcOracleUtils.pas
+++ b/src/dbc/ZDbcOracleUtils.pas
@@ -201,8 +201,8 @@ type
     Scale:     sb1; //field.scale used 4 out params
     ColType:   TZSQLType; //Zeos SQLType
     Data: TBytes;
-    DataIndicators:  TArray<sb2>;
-    DataLengths:    TArray<ub2>;
+    DataIndicators:  Array of sb2;
+    DataLengths:     Array of ub2;
   end;
 
   TZSQLVarDynArray = Array of TZSQLVar;

--- a/src/dbc/ZDbcOracleUtils.pas
+++ b/src/dbc/ZDbcOracleUtils.pas
@@ -200,6 +200,9 @@ type
     Precision: sb2; //field.precision used 4 out params
     Scale:     sb1; //field.scale used 4 out params
     ColType:   TZSQLType; //Zeos SQLType
+    Data: TBytes;
+    DataIndicators:  TArray<sb2>;
+    DataLengths:    TArray<ub2>;
   end;
 
   TZSQLVarDynArray = Array of TZSQLVar;
@@ -1227,8 +1230,10 @@ label VCS;
   procedure CharacterSizeToByteSize(var DataSize: ub4; Precision: Integer);
   begin
     //EH: Note NCHAR, NVARCHAR2, CLOB, and NCLOB columns are always character-based.
+    // Adjusted the UTF16 buffer size down to 2 times character size instead of 4.  Needs testing.
+    // The question is... can a single ansi character become two UTF16 chars (a surrogate pair.)
     if (ScaleOrCharSetForm = SQLCS_NCHAR) or (ConSettings.ClientCodePage.Encoding = ceUTF16)
-    then DataSize := Precision shl 2
+    then DataSize := Precision shl 1
     else if (ConSettings.ClientCodePage.CharWidth > 1)
       then DataSize := Precision * Byte(ConSettings.ClientCodePage.CharWidth)
       else DataSize := Precision;


### PR DESCRIPTION
This needs testing as well as a check that the code meets Zeoslib coding standards.

-Mark