### PR TITLE
Zeos Library fails to build due to an error in ZDbcInterbaseFirebirdMetadata.pas

### DIFF
--- a/src/dbc/ZDbcInterbaseFirebirdMetadata.pas
+++ b/src/dbc/ZDbcInterbaseFirebirdMetadata.pas
@@ -451,7 +451,7 @@ var
   isc_info: Byte;
   P: PChar;
   PA: PAnsiChar absolute P;
-  //L: NativeUInt;
+  L: NativeUInt;
   FbPos: Integer;
 begin
   {$IFDEF WITH_VAR_INIT_WARNING}L := 0;{$ENDIF}


### PR DESCRIPTION
Quick fix to bypass the build error while installing zeos library with fpcupdeluxe: zeos\src\dbc\ZDbcInterbaseFirebirdMetadata.pas(457,33) Error: (5000) Identifier not found "L"