### PR TITLE
[ODBC] TZQuery does not generate a change of text blob field

### DIFF
--- a/src/component/ZAbstractDataset.pas
+++ b/src/component/ZAbstractDataset.pas
@@ -913,6 +913,7 @@ var
             try
               DestStream := DestDataset.CreateBlobStream(DestField, bmWrite);
               try
+                DestStream.Size := 0;
                 DestStream.CopyFrom(SrcStream, 0);
               finally
                 DestStream.Free;

--- a/src/dbc/ZDbcODBCResultSet.pas
+++ b/src/dbc/ZDbcODBCResultSet.pas
@@ -1669,6 +1669,7 @@ procedure TAbstractODBCResultSet.LoadUnBoundColumns;
 var
   ColumnIndex: Integer;
   StrLen_or_IndPtr: PSQLLEN;
+  ZeroBuffer : Byte;  
 begin
   for ColumnIndex := fFirstGetDataIndex to fLastGetDataIndex do
     with TZODBCColumnInfo(ColumnsInfo[ColumnIndex]) do begin
@@ -1682,7 +1683,7 @@ begin
         else begin
           { check out length of lob }
           CheckStmtError(fPlainDriver.SQLGetData(fPHSTMT^, ColumnIndex+1,
-            ODBC_CType, Pointer(1){can not be nil}, 0, StrLen_or_IndPtr));
+            ODBC_CType, @ZeroBuffer, 0, StrLen_or_IndPtr));
           if StrLen_or_IndPtr^ = SQL_NULL_DATA then
             PIZlob(@ColumnBuffer)^ := nil
           else if ColumnType = stBinaryStream


### PR DESCRIPTION
TZQuery does not generate a change of text blob field when new string length small or equal to old value

Problem in TZVarVarLenDataRefStream, CopyFrom method does no change FUpdated property, FUpdatet changes in Realloc

Workaround to change capacity to zero, because CopyFrom method not virtual in TStream