### PR TITLE
Access violation when exception in unprepare

### DIFF
--- a/src/component/ZAbstractRODataset.pas
+++ b/src/component/ZAbstractRODataset.pas
@@ -1697,9 +1697,16 @@ end;
 }
 destructor TZAbstractRODataset.Destroy;
 begin
-  Unprepare;
-  if Assigned(Connection) then
-    SetConnection(nil);
+  try
+    Unprepare;
+    if Assigned(Connection) then SetConnection(nil);
+  finally
+    if FConnection <> nil then
+    begin
+      FConnection.UnregisterComponent(Self);
+      FConnection := nil;
+    end;
+  end;
 
   FreeAndNil(FSQL);
   FreeAndNil(FParams);

--- a/src/dbc/ZDbcCachedResultSet.pas
+++ b/src/dbc/ZDbcCachedResultSet.pas
@@ -2369,7 +2369,7 @@ begin
       end;
     end;
   end;
-  FRowsList.Add(NewRowAccessor.RowBuffer);
+  FRowsList.Add(FRowAccessor.RowBuffer);
   FRowAccessor.ClearBuffer(FInsertedRow, True);
 
   LastRowNo := FRowsList.Count;

--- a/src/dbc/ZDbcCachedResultSet.pas
+++ b/src/dbc/ZDbcCachedResultSet.pas
@@ -2369,7 +2369,7 @@ begin
       end;
     end;
   end;
-  FRowsList.Add(FRowAccessor.RowBuffer);
+  FRowsList.Add(NewRowAccessor.RowBuffer);
   FRowAccessor.ClearBuffer(FInsertedRow, True);
 
   LastRowNo := FRowsList.Count;


### PR DESCRIPTION
Using odbc, in some cases in unprepare (resultset.close) raised exception

in this code:

```
query.free;
connection.free;

```

if exception raised in query.free, query is destroyed, but link with connection is not removed. Then in connection.free called LinkedComponents.setconnection(nil) on object, that already destroyed