### PR TITLE
Inserting new row in TZQuery does not show correct data

### DIFF
--- a/src/dbc/ZDbcCachedResultSet.pas
+++ b/src/dbc/ZDbcCachedResultSet.pas
@@ -2369,7 +2369,7 @@ begin
       end;
     end;
   end;
-  FRowsList.Add(NewRowAccessor.RowBuffer);
+  FRowsList.Add(FRowAccessor.RowBuffer);
   FRowAccessor.ClearBuffer(FInsertedRow, True);
 
   LastRowNo := FRowsList.Count;

--- a/src/dbc/ZDbcCachedResultSet.pas
+++ b/src/dbc/ZDbcCachedResultSet.pas
@@ -2369,7 +2369,7 @@ begin
       end;
     end;
   end;
-  FRowsList.Add(FRowAccessor.RowBuffer);
+  FRowsList.Add(NewRowAccessor.RowBuffer);
   FRowAccessor.ClearBuffer(FInsertedRow, True);
 
   LastRowNo := FRowsList.Count;


### PR DESCRIPTION
Inserting new row in TZQuery posting data to database, but showing empty row in app

problem in:

```
FRowsList.Add(FRowAccessor.RowBuffer);
FRowAccessor.ClearBuffer(FInsertedRow, True);

```

After PostUpdates FRowAccessor.RowBuffer = FInsertedRow, and FRowAccessor.ClearBuffer(FInsertedRow, True); clear new row in dataset