### PR TITLE
Inserting new row in TZQuery show empty data

### DIFF
--- a/src/dbc/ZDbcCachedResultSet.pas
+++ b/src/dbc/ZDbcCachedResultSet.pas
@@ -2339,13 +2339,14 @@ end;
   The cursor must be on the insert row when this method is called.
 }
 procedure TZAbstractCachedResultSet.InsertRow;
-var TempRow: PZRowBuffer;
+var TempRow, NewRow : PZRowBuffer;
   Succeeded: Boolean;
 begin
   CheckUpdatable;
   { Creates a new row. }
   TempRow := FRowAccessor.RowBuffer;
   FRowAccessor.Alloc;
+  NewRow := FRowAccessor.RowBuffer;
   FRowAccessor.CopyFrom(FInsertedRow);
   FRowAccessor.RowBuffer^.UpdateType := utInserted;
   FRowAccessor.RowBuffer^.Index := GetNextRowIndex;
@@ -2357,6 +2358,7 @@ begin
     Succeeded := False;
     try
       PostUpdates;
+      FRowAccessor.RowBuffer := NewRow;
       Succeeded := True;
     finally //EH no reraising of an Exception required -> keep original stack frame i.e. MadExcept
       if not Succeeded then begin


### PR DESCRIPTION
When using TZUpdateSQL.BeforeInsertSQL.

I am using dynamicly build statement for insert row in ZUpdateSQL.BeforeInsertSQL

I compare fields old value with new value:

`(SQLQuery.Fields[i].OldValue <> SQLQuery.Fields[i].NewValue)`

Its calls TField.GetFieldData, witch calls ZAbstractCachedResultSet.MoveToInsertRow.
<img width="1914" height="1077" alt="zeos_1" src="https://github.com/user-attachments/assets/92022296-c065-432e-893c-41b266e44f8a" />

ZAbstractCachedResultSet.MoveToInsertRow changes FRowAccessor.RowBuffer to FInsertedRow

<img width="1686" height="827" alt="zeos_2" src="https://github.com/user-attachments/assets/73eab140-4224-4c07-85fe-a3545442b29f" />

And then FRowsList.Add(FRowAccessor.RowBuffer) adds incorrect data.

P.S. 

Full code of BeforeInsertSQL:

```
procedure TForm6.ZUpdateSQLBeforeInsertSQL(Sender: TObject);
Var Fields, Values : string;
    i : integer;
    SQLQuery : TZQuery;
    SQLUpdate : TZUpdateSQL;
begin

  SQLUpdate := TZUpdateSQL(Sender);
  SQLQuery := TZQuery(SQLUpdate.DataSet);

  TZUpdateSQL(Sender).InsertSQL.Text := '';
  Fields := '';
  Values := '';

  for i := 0 to SQLQuery.Fields.Count - 1 do
  if SQLQuery.Fields[i].FieldKind = fkData then
  begin
    if pfInUpdate in SQLQuery.Fields[i].ProviderFlags then
      if (SQLQuery.UpdateMode = umUpdateAll) or (SQLQuery.Fields[i].OldValue <> SQLQuery.Fields[i].NewValue) then
      begin
        Fields := Fields + ', ' + SQLQuery.Fields[i].FieldName;
        Values := Values + ', ' + ':' + SQLQuery.Fields[i].FieldName;
      end;
  end;
  Delete(Fields, 1, 2);
  Delete(Values, 1, 2);

  for i := 0 to SQLQuery.DbcResultSet.GetMetadata.GetColumnCount - 1 do
    if SQLQuery.DbcResultSet.GetMetadata.GetTableName(i) <> '' then
    begin
      TZUpdateSQL(Sender).InsertSQL.Text := 'insert into ' + SQLQuery.DbcResultSet.GetMetadata.GetTableName(i) + ' (' + Fields + ') values (' + Values + ')';
      break;
    end;

end;

```
