### PR TITLE
Access violantion in Test_IBFBEventListener

### DIFF
--- a/src/dbc/ZDbcInterbase6.pas
+++ b/src/dbc/ZDbcInterbase6.pas
@@ -532,6 +532,7 @@ var
   P, PEnd: PChar;
   TrHandle: TISC_TR_HANDLE;
   DBCreated: Boolean;
+  TempEventList: TZFirebirdInterbaseEventList;
   procedure PrepareDPB;
   var
     R: RawByteString;
@@ -731,7 +732,13 @@ reconnect:
     (FMetadata as TZInterbase6DatabaseMetadata).SetUTF8CodePageInfo;
     if (FCLientCodePage <> DBCP) then begin
       Info.Values[ConnProps_isc_dpb_lc_ctype] := DBCP;
-      InternalClose;
+      try
+        TempEventList := FEventList;
+        FEventList := nil;
+        InternalClose;
+      finally
+        FEventList := TempEventList;
+      end;
       goto reconnect; //build new TDB and reopen in CS_NONE mode
     end;
   end else if FClientCodePage = '' then


### PR DESCRIPTION
I have Firebird database with default charset = 'NONE'

In test I have access violation in Test_IBFBEventListener

<img width="1357" height="753" alt="image" src="https://github.com/user-attachments/assets/9a057aff-55ff-4c5b-8e52-983dda1072c2" />

Problem is in procedure TZInterbase6Connection.Open; Because database encoding is NONE, method reconnect with this encoding to database, and before reconnect calls InternalClose; InternalClose calls free on FEventList

<img width="1548" height="1017" alt="image" src="https://github.com/user-attachments/assets/74d65c06-8015-4547-9439-bfdf2df8d206" />

<img width="1604" height="986" alt="image" src="https://github.com/user-attachments/assets/9ed58a8f-3a97-451e-9de0-de1ee2d8e745" />

My test configuration attched

Thanks!

[database.zip](https://github.com/user-attachments/files/21565741/database.zip)

