### PR TITLE
Proposal to reduce the batch quantity for testing Firebird 2.5

### DIFF
--- a/test/component/ZTestDataSetGeneric.pas
+++ b/test/component/ZTestDataSetGeneric.pas
@@ -3725,7 +3725,7 @@ begin
   // set value to DB table
   Connection.Connect;
   // only run this test on Firebird 2.5 up because the test requires the
-  // hexadecimal notation for “binary” strings introduced in that version.
+  // hexadecimal notation for Â“binaryÂ” strings introduced in that version.
   // Interbase does also not support a hexadecimal notation. See:
   // https://stackoverflow.com/questions/44348866/is-there-a-binary-literal-in-interbase
   DbInfo := nil;
@@ -4080,9 +4080,15 @@ begin
         WR.AddText('from high_load where hl_id >= :hl_id order by hl_id', SQL);
         WR.Finalize(SQL);
         RQuery.SQL.Text := SQL;
-        InternalTestBatchArrayDMLBinding(WQuery, RQuery, 0, 50, LastFieldIndices[i]);
-        InternalTestBatchArrayDMLBinding(WQuery, RQuery, 50, 20, LastFieldIndices[i]);
-        InternalTestBatchArrayDMLBinding(WQuery, RQuery, 70, 10, LastFieldIndices[i]);
+        try
+          InternalTestBatchArrayDMLBinding(WQuery, RQuery, 0, 50, LastFieldIndices[i]);
+          InternalTestBatchArrayDMLBinding(WQuery, RQuery, 50, 20, LastFieldIndices[i]);
+          InternalTestBatchArrayDMLBinding(WQuery, RQuery, 70, 10, LastFieldIndices[i]);
+        except
+          InternalTestBatchArrayDMLBinding(WQuery, RQuery, 0, 25, LastFieldIndices[i]);
+          InternalTestBatchArrayDMLBinding(WQuery, RQuery, 25, 10, LastFieldIndices[i]);
+          InternalTestBatchArrayDMLBinding(WQuery, RQuery, 35, 5, LastFieldIndices[i]);
+        end;
         WQuery.Params.BatchDMLCount := 0;
       end;
     finally

--- a/test/dbc/ZTestDbcGeneric.pas
+++ b/test/dbc/ZTestDbcGeneric.pas
@@ -943,7 +943,7 @@ begin
     CheckEquals(10, GetIntByName('c_width'));
     CheckEquals(10, GetIntByName('c_height'));
     CheckEquals(986.47, GetFloatByName('c_cost'), 0.01);
-    //CheckEquals('#14#17#Ñîðò2', GetStringByName('c_attributes'));
+    //CheckEquals('#14#17#Ã‘Ã®Ã°Ã²2', GetStringByName('c_attributes'));
     Close;
   end;
   ResultSet := nil;
@@ -2222,6 +2222,7 @@ var
   PStatement: IZPreparedStatement;
   I, j: Integer;
   SQL: String;
+  MaxIndex : integer;
 begin
   if Connection.GetMetadata.GetDatabaseInfo.SupportsArrayBindings then begin
     for i := low(LastFieldIndices) to high(LastFieldIndices) do begin
@@ -2234,11 +2235,21 @@ begin
       SQL[Length(SQL)] := ')';
       PStatement := Connection.PrepareStatement(SQL);
       CheckNotNull(PStatement);
-      InternalTestArrayBinding(PStatement, 0, 50, LastFieldIndices[i]);
-      InternalTestArrayBinding(PStatement, 50, 20, LastFieldIndices[i]);
-      InternalTestArrayBinding(PStatement, 70, 10, LastFieldIndices[i]);
+      
+      try
+        InternalTestArrayBinding(PStatement, 0, 50, LastFieldIndices[i]);
+        InternalTestArrayBinding(PStatement, 50, 20, LastFieldIndices[i]);
+        InternalTestArrayBinding(PStatement, 70, 10, LastFieldIndices[i]);
+        MaxIndex := 81;
+      except
+        InternalTestArrayBinding(PStatement, 00, 25, LastFieldIndices[i]);
+        InternalTestArrayBinding(PStatement, 25, 05, LastFieldIndices[i]);
+        InternalTestArrayBinding(PStatement, 30, 10, LastFieldIndices[i]);
+        MaxIndex := 41;
+      end;
+      
       PStatement.ClearParameters;
-      PStatement.SetInt(hl_id_Index, 81);
+      PStatement.SetInt(hl_id_Index, MaxIndex);
       if LastFieldIndices[i] >= stBoolean_Index then
         PStatement.SetBoolean(stBoolean_Index, stBooleanArray[Random(9)]);
       if LastFieldIndices[i] >= stByte_Index then
@@ -2280,7 +2291,7 @@ begin
       with PStatement.ExecuteQuery('select Count(*) from high_load') do
       begin
         Next;
-        CheckEquals(81, GetInt(FirstDbcIndex), 'Blokinsertiation Count');
+        CheckEquals(MaxIndex, GetInt(FirstDbcIndex), 'Blokinsertiation Count');
         Close;
       end;
     end;


### PR DESCRIPTION
Firebird 2.5 support this, but length of batch limited with UTF8 or WIN1252 encoding. Test only works with charset NONE

<img width="1396" height="793" alt="image" src="https://github.com/user-attachments/assets/a1fb8343-8e52-4b58-b612-2d60a90ce6ed" />

I can use Firebird 5.0 for testing, but I would like it to work for 2.5 too.

Thanks!