### PR TITLE
Proposal for TestForum225651

### DIFF
--- a/src/component/ZAbstractRODataset.pas
+++ b/src/component/ZAbstractRODataset.pas
@@ -76,7 +76,7 @@ uses
   TypInfo, {$IFDEF MSEgui}mclasses, mdb{$ELSE}DB{$ENDIF},
   {$IFDEF WITH_GENERIC_TLISTTFIELD}Generics.Collections,{$ENDIF}
   {$IFNDEF NO_UNIT_CONTNRS}Contnrs,{$ENDIF}
-  ZSysUtils, ZCompatibility, ZExpression, ZClasses,
+  ZSysUtils, ZCompatibility, ZExpression, ZClasses, ZDbcInterbase6Statement, ZDbcFirebirdInterbase,
   ZDbcIntfs, ZDbcCache, ZDbcCachedResultSet, ZTokenizer,
   ZAbstractConnection, ZDatasetUtils, ZSqlStrings, ZFormatSettings, ZTransaction, ZExceptions
   {$IFNDEF DISABLE_ZPARAM},ZDatasetParam{$ENDIF};
@@ -3759,6 +3759,8 @@ begin
     end;
     {$ELSE}
     Result := TxnCon.PrepareStatementWithParams(SQL, Temp);
+    if Assigned(FTransaction) and (Result is TZInterbase6PreparedStatement) then // assing transaction for IB/FB 
+      TZInterbase6PreparedStatement(Result).IBTransaction := IZInterbaseFirebirdTransaction(Txn); 
     {$ENDIF}
   finally
     Temp.Free;


### PR DESCRIPTION
https://zeoslib.sourceforge.io/viewtopic.php?t=225651

<img width="1395" height="786" alt="image" src="https://github.com/user-attachments/assets/972cd13f-b8d0-4074-9614-057675b2b159" />

I can't imagine how else this problem can be solved without rewriting the PreparedStatement interface (adding the ability to transfer a transaction when creating it) and all other depend classes. 

Patch for ZAbstractRODataset.pas is not clear, but it is a fastest way to send transaction to PreparedStatement. 

Maybe you have better ideas?
