### PR TITLE
TZODBCConnectionW.GetCatalog

### DIFF
--- a/src/dbc/ZDbcODBCCon.pas
+++ b/src/dbc/ZDbcODBCCon.pas
@@ -1125,18 +1125,17 @@ var
   {$ENDIF}
   aLen: SQLINTEGER;
   Ret: SQLRETURN;
+  Buffer : array[0 .. 8191] of WideChar;
 begin
   Result := inherited GetCatalog;
   if Result = '' then begin
     RET := TODBC3UnicodePlainDriver(fODBCPlainDriver).SQLGetConnectAttrW(fHDBC,
-      SQL_ATTR_CURRENT_CATALOG, nil, 0, @aLen);
+      SQL_ATTR_CURRENT_CATALOG, @Buffer, Length(Buffer), @aLen);
     if Ret <> SQL_SUCCESS then
       HandleErrorOrWarning(Ret, fHDBC, SQL_HANDLE_DBC, 'GET CATALOG', lcOther, Self);
     if aLen > 0 then begin
       {$IFDEF UNICODE}
-      SetLength(Result, aLen shr 1);
-      Ret := TODBC3UnicodePlainDriver(fODBCPlainDriver).SQLGetConnectAttrW(fHDBC,
-        SQL_ATTR_CURRENT_CATALOG, Pointer(Result), aLen+2, @aLen);
+      SetString(result, PWideChar(@Buffer[0]), aLen shr 1); 
       {$ELSE}
       {$IFDEF WITH_VAR_INIT_WARNING}Buf := '';{$ENDIF}
       SetLength(Buf, aLen shr 1);
@@ -1526,3 +1525,4 @@ finalization
 
 {$ENDIF ZEOS_DISABLE_ODBC} //if set we have an empty unit
 end.
+


### PR DESCRIPTION
I sow you quastion on https://postgrespro.ru/list/id/CAFGcedVioNNaedu4fiCFNOL=7LKC41gf5eWgDCz3CHd-CL8K3g@mail.gmail.com

And I have a problem with catalog name on Firebird too (odbc_w + Firebird)

In my case if SQLGetConnectAttrW calls with nil pointer and zero length, aLen in case randomly is 1000, 2000, 100K ets.

`RET := TODBC3UnicodePlainDriver(fODBCPlainDriver).SQLGetConnectAttrW(fHDBC,  SQL_ATTR_CURRENT_CATALOG, nil, 0, @aLen);`

In result I get catalog name as "c:\test\test.fdb#0#0#0#0#0#0#0#0#0.....#0", witch cause range check errors in other code

My working code is call SQLGetConnectAttrW with a large buffer (8K)