### PR TITLE
fix: 🩹  This wasn't compiling properly on Linux

### DIFF
--- a/src/dbc/ZDbcDbLibResultSet.pas
+++ b/src/dbc/ZDbcDbLibResultSet.pas
@@ -72,7 +72,7 @@ uses
   FmtBCD,
   ZDbcIntfs, ZDbcResultSet, ZCompatibility, ZDbcResultsetMetadata,
   ZDbcGenericResolver, ZDbcCachedResultSet, ZDbcCache, ZDbcDBLib,
-  ZPlainDBLibDriver;
+  ZPlainDbLibDriver;
 
 type
   {$IFNDEF ZEOS_DISABLE_DBLIB} //if set we have an empty unit

--- a/src/plain/ZPlainDbLibDriver.pas
+++ b/src/plain/ZPlainDbLibDriver.pas
@@ -1214,7 +1214,7 @@ type
   TDbLibMessageHandler = class; //forward
   {$ENDIF TEST_CALLBACK}
   TDBLibraryVendorType = (lvtFreeTDS, lvtMS, lvtSybase);
-  TZDBLIBPLainDriver = class(TZAbstractPlainDriver, IZDBLibPlainDriver)
+  TZDBLIBPLainDriver = class(TZAbstractPlainDriver{$IFDEF MSWINDOWS}, IZDBLibPlainDriver{$ENDIF})
   private
     {$IFDEF TEST_CALLBACK}
     FSQLErrorHandlerList: TZDBLibErrorList;


### PR DESCRIPTION
Just two small fixes so ZeosDBO compiles properly on Linux:

- one wrong lowercase letter was preventing the compilation from finding the correct .PPU file

- the IZDBLibPlainDriver was only implemented on Windows
