### PR TITLE
DuckDB Reconnect fix

### DIFF
--- a/src/dbc/ZDbcDuckDBStatement.pas
+++ b/src/dbc/ZDbcDuckDBStatement.pas
@@ -77,11 +77,13 @@ type
   protected
     FPlainDriver: TZDuckDBPlainDriver;
     FStatement: TDuckDB_Prepared_Statement;
+    FDuckResult: TDuckDB_Result;
     procedure CheckDuckDbError(AStatement: TDuckDB_Prepared_Statement);
     procedure BindParams;
     function CreateResultSet(Const DuckResult: TDuckDB_Result): IZResultSet;
   public
     constructor Create(const Connection: IZConnection; const SQL: string; Info: TStrings);
+    destructor Destroy; override;
 
     /// <summary>
     ///   Executes the SQL query in this PreparedStatement object
@@ -198,6 +200,13 @@ begin
     FOpenResultSet := Pointer(Result);
 end;
 
+destructor TZDbcDuckDBPreparedStatement.Destroy;
+begin
+  FPlainDriver.DuckDB_Destroy_Prepare(@FStatement);
+  FPlainDriver.DuckDB_Destroy_Result(@FDuckResult);
+  inherited;
+end;
+
 function TZDbcDuckDBPreparedStatement.ExecuteQueryPrepared: IZResultSet;
 begin
   ExecutePrepared;
@@ -214,10 +223,10 @@ function TZDbcDuckDBPreparedStatement.ExecutePrepared: Boolean;
 var
   xSQL: UTF8String;
   Res: TDuckDB_State;
-  DuckResult: TDuckDB_Result;
 begin
   // free a previous prepared statement, if there is one
   FPlainDriver.DuckDB_Destroy_Prepare(@FStatement);
+  FPlainDriver.DuckDB_Destroy_Result(@FDuckResult);
 
   xSQL := {$IFDEF UNICODE}UTF8Encode(FWSQL){$ELSE}FASQL{$ENDIF};
   Res := FPlainDriver.DuckDB_Prepare(
@@ -226,12 +235,12 @@ begin
   if Res <> DuckDBSuccess then
      CheckDuckDbError(FStatement);
   BindParams;
-  if FPlainDriver.DuckDB_Execute_Prepared(FStatement, @DuckResult) <> DuckDBSuccess then
-    (GetConnection as IZDbcDuckDBConnection).CheckDuckDbError(@DuckResult);
+  if FPlainDriver.DuckDB_Execute_Prepared(FStatement, @FDuckResult) <> DuckDBSuccess then
+    (GetConnection as IZDbcDuckDBConnection).CheckDuckDbError(@FDuckResult);
 
-  LastUpdateCount := FPlainDriver.DuckDB_Rows_Changed(@DuckResult);
-  if FPlainDriver.DuckDB_Result_Return_Type(DuckResult) = DUCKDB_RESULT_TYPE_QUERY_RESULT then begin
-    CreateResultSet(DuckResult);
+  LastUpdateCount := FPlainDriver.DuckDB_Rows_Changed(@FDuckResult);
+  if FPlainDriver.DuckDB_Result_Return_Type(FDuckResult) = DUCKDB_RESULT_TYPE_QUERY_RESULT then begin
+    CreateResultSet(FDuckResult);
     Result := True;
   end else begin
     Result := False;


### PR DESCRIPTION
These changes are an attempt to fix the error when reconnecting to the same database which appear to be caused by not calling destroy_result().