### PR TITLE
Fix: Access Violation in BCD2SQLNumeric (ZDbcUtils.pas) when TBCD value is 0 via OLEDB

### DIFF
--- a/src/dbc/ZDbcUtils.pas
+++ b/src/dbc/ZDbcUtils.pas
@@ -810,6 +810,13 @@ begin
   Dest.scale := Src.SignSpecialPlaces and $3F;
   Dest.sign := Byte(Src.SignSpecialPlaces and (1 shl 7) = 0);
 
+  // Prevent pointer underflow/Access Violation when TBCD is 0 (Precision = 0)
+  if Src.Precision = 0 then
+  begin
+    Dest.precision := 1; // OLEDB often requires precision > 0 even for zero values
+    Exit; 
+  end;
+  
   pFirstNibble := @Src.Fraction[0];
   pLastNibble := pFirstNibble+((Src.Precision -1) shr 1);
   pNibble := pLastNibble-1;


### PR DESCRIPTION
When using ZeosLib 8.0 with the oledb protocol (connecting to MS SQL Server), posting a value of 0 to a NUMERIC or DECIMAL column that is declared as NOT NULL results in an Access Violation. This commonly happens when entering 0 through a data-aware grid (e.g., TRxDBGrid or standard TDBGrid).
When the TBCD value is exactly 0, its Precision property is 0.
The pointer arithmetic fails on this line:
pLastNibble := pFirstNibble+((Src.Precision -1) shr 1);