### PR TITLE
Update ZDbcODBCResultSet.pas

### DIFF
--- a/src/dbc/ZDbcODBCResultSet.pas
+++ b/src/dbc/ZDbcODBCResultSet.pas
@@ -2322,7 +2322,7 @@ begin
     if StrLen_or_IndPtr^ >= 0 then begin
       SetCapacity(StrLen_or_IndPtr^);
       OffSetPtr := @FDataRefAddress^.VarLenData.Data;
-      for i := 1 to StrLen_or_IndPtr^ div MaxBufSize do begin
+      for i := 1 to (StrLen_or_IndPtr^ - 1) div (MaxBufSize-SizeOf(WideChar)) do begin
         Success := SQL_SUCCESS_WITH_INFO = PlainDriver.SQLGetData(StmtHandle, ColumnNumber, SQL_C_WCHAR, OffSetPtr, MaxBufSize, StrLen_or_IndPtr);
         Assert(Success);
         Inc(OffSetPtr, (MaxBufSize-SizeOf(WideChar)));


### PR DESCRIPTION
I have a problem with BLOB size = 1167352

for i := 1 to (StrLen_or_IndPtr^ div MaxBufSize) makes 18 iterations. MaxBufSize = 61440

After loop whe have: 
1167352 - 18 * (61440 - 2) = 61468 bytes

Last call PlainDriver.SQLGetData(StmtHandle, ColumnNumber, SQL_C_WCHAR, OffSetPtr, MaxBufSize, StrLen_or_IndPtr) get 61438 bytes, 30 bytes absent in total 

